### PR TITLE
Refactor correlate

### DIFF
--- a/skan/image_stats.py
+++ b/skan/image_stats.py
@@ -32,7 +32,7 @@ def mesh_sizes(skeleton):
     >>> from skan.nputil import pad
     >>> image2 = pad(image, 1)  # make sure mesh not touching border
     >>> print(mesh_sizes(image2))  # sizes in row order of first pixel in space
-    [7, 2, 3, 1]
+    [7 2 3 1]
     """
     spaces = ~skeleton.astype(bool)
     labeled = ndi.label(spaces)[0]

--- a/skan/test/test_vendored_correlate.py
+++ b/skan/test/test_vendored_correlate.py
@@ -37,7 +37,7 @@ def test_reference_correlation():
     kern = reduce(np.outer, [[-1, 0, 0, 1]] * ndim).reshape((4,) * ndim)
     px = np.pad(x, (2, 1), mode='reflect')
     pxi = integral_image(px)
-    mean_fast = th.correlate_nonzeros(pxi, kern / 3 ** ndim)
+    mean_fast = th.correlate_sparse(pxi, kern / 3 ** ndim, mode='valid')
     mean_ref = ndi.correlate(x, np.ones((3,) * ndim) / 3 ** ndim,
                              mode='mirror')
     np.testing.assert_allclose(mean_fast, mean_ref)

--- a/skan/vendored/thresholding.py
+++ b/skan/vendored/thresholding.py
@@ -66,7 +66,7 @@ def correlate_sparse(image, kernel, mode='reflect'):
     indices = np.nonzero(kernel)
     offsets = np.ravel_multi_index(indices, padded_image.shape)
     values = kernel[indices]
-    result = np.zeros([a + b + 1
+    result = np.zeros([a - b + 1
                        for a, b in zip(padded_image.shape, kernel.shape)])
     corner_multi_indices = broadcast_mgrid([np.arange(i)
                                             for i in result.shape])


### PR DESCRIPTION
Rename `correlate_nonzeros` to the slightly more descriptive `correlate_sparse`, and add a `mode` parameter to bring it more into feature parity with `ndimage.correlate`.