### PR TITLE
Add support for loading and saving config files

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,14 @@
+{
+"crop radius": 0,
+"smoothing radius": 0.1,
+"threshold radius": 5e-8,
+"brightness offset": 0.075,
+"image format": "fei",
+"scale metadata path": "Scan/PixelHeight",
+"save skeleton plot?": true,
+"prefix for skeleton plots": "skeleton-plot-",
+"full stats filename": "skeleton.csv",
+"image stats filename": "image-stats.csv",
+"input files": ["image0.tif", "image1.tif"],
+"output folder": "~/Desktop"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-image>=0.12
 imageio>=2.0
 tqdm>=4.0
 dask>=0.12
+click>=0.5

--- a/skan/gui.py
+++ b/skan/gui.py
@@ -82,7 +82,7 @@ class Launch(tk.Tk):
                 self.input_files = value
                 params_dict.pop(param)
             elif param.lower() == 'output folder':
-                self.output_folder = value
+                self.output_folder = os.path.expanduser(value)
                 params_dict.pop(param)
         for param in params_dict:
             print(f'Parameter not recognised: {param}')

--- a/skan/gui.py
+++ b/skan/gui.py
@@ -8,7 +8,7 @@ from tkinter import ttk
 import click
 
 
-from . import pipe
+from . import pipe, __version__
 
 
 STANDARD_MARGIN = (3, 3, 12, 12)
@@ -84,8 +84,23 @@ class Launch(tk.Tk):
             elif param.lower() == 'output folder':
                 self.output_folder = os.path.expanduser(value)
                 params_dict.pop(param)
+            elif param.lower() == 'version':
+                print(f'Parameter file version: {params_dict.pop(param)}')
         for param in params_dict:
             print(f'Parameter not recognised: {param}')
+
+    def save_parameters(self, filename):
+        out = {p._name.lower(): p.get() for p in self.parameters}
+        out['input files'] = self.input_files
+        out['output folder'] = self.output_folder
+        out['version'] = __version__
+        attempt = 0
+        while os.path.exists(filename):
+            base, ext = os.path.splitext(filename)
+            filename = f'{base} ({attempt}).{ext}'
+            attempt += 1
+        with open(filename, mode='wt') as fout:
+            json.dump(out, fout, indent=0)
 
     def create_main_frame(self):
         main = ttk.Frame(master=self, padding=STANDARD_MARGIN)
@@ -161,6 +176,8 @@ class Launch(tk.Tk):
                                         self.full_output_filename.get()))
         result_image.to_csv(os.path.join(self.output_folder,
                                          self.image_output_filename.get()))
+        self.save_parameters(os.path.join(self.output_folder,
+                                          'skan-config.json'))
 
 @click.command()
 @click.option('-c', '--config', default='',

--- a/skan/gui.py
+++ b/skan/gui.py
@@ -114,6 +114,7 @@ class Launch(tk.Tk):
         buttons = ttk.Frame(master=parent, padding=STANDARD_MARGIN)
         buttons.grid(sticky='nsew')
         actions = [
+            ('Choose config', self.choose_config_file),
             ('Choose files', self.choose_input_files),
             ('Choose output folder', self.choose_output_folder),
             ('Run', self.run)
@@ -122,6 +123,10 @@ class Launch(tk.Tk):
             button = ttk.Button(buttons, text=action_name,
                                 command=action)
             button.grid(row=0, column=col)
+
+    def choose_config_file(self):
+        config_file = tk.filedialog.askopenfilename()
+        self.parameter_config(config_file)
 
     def choose_input_files(self):
         self.input_files = tk.filedialog.askopenfilenames()

--- a/skan/gui.py
+++ b/skan/gui.py
@@ -100,7 +100,7 @@ class Launch(tk.Tk):
             filename = f'{base} ({attempt}).{ext}'
             attempt += 1
         with open(filename, mode='wt') as fout:
-            json.dump(out, fout, indent=0)
+            json.dump(out, fout, indent=2)
 
     def create_main_frame(self):
         main = ttk.Frame(master=self, padding=STANDARD_MARGIN)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - pytest>=3*
 - coverage>=4.0
 - pytest-cov>=2.2
+- click>=0.5
 - pip:
   - hypothesis>=3.6
   - imageio>=2.0


### PR DESCRIPTION
This PR adds the following features:
- launch with `skan-gui -c path/to/config-file.json` to automatically load those settings
- launch normally then click the `Load config` button to select a configuration file
- load configuration files sequentially. Only the parameters in each file are touched.
- a configuration file with settings and version number is saved with each run