### PR TITLE
Handle direct tip-to-junction edges

### DIFF
--- a/skan/_testdata.py
+++ b/skan/_testdata.py
@@ -53,3 +53,8 @@ skeleton3d = np.array([[[1, 0, 0, 0, 0],
                         [0, 0, 0, 0, 1]]], dtype=bool)
 
 topograph1d = np.array([3., 2., 3.])
+
+skeleton4 = np.array([[1, 0, 0, 0, 0],
+                      [0, 1, 1, 1, 1],
+                      [0, 1, 0, 0, 0],
+                      [0, 1, 0, 0, 0]], dtype=bool)

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -351,27 +351,38 @@ def _expand_path(graph, source, step, visited, degrees):
 def _branch_statistics_loop(jgraph, degrees, visited, result):
     num_results = 0
     for node in range(1, jgraph.shape[0]):
-        if degrees[node] == 2 and not visited[node]:
-            visited[node] = True
-            left, right = jgraph.neighbors(node)
-            id0, d0, n0, s0, deg0 = _expand_path(jgraph, node, left,
-                                                 visited, degrees)
-            if id0 == node:  # standalone cycle
-                id1, d1, n1, s1, deg1 = node, 0, 0, 0., 2
-                kind = 3
-            else:
-                id1, d1, n1, s1, deg1 = _expand_path(jgraph, node, right,
+        if not visited[node]:
+            if degrees[node] == 2:
+                visited[node] = True
+                left, right = jgraph.neighbors(node)
+                id0, d0, n0, s0, deg0 = _expand_path(jgraph, node, left,
                                                      visited, degrees)
-                kind = 2  # default: junction-to-junction
-                if deg0 == 1 and deg1 == 1:  # tip-tip
-                    kind = 0
-                elif deg0 == 1 or deg1 == 1:  # tip-junct, tip-path impossible
-                    kind = 1
-            counts = n0 + n1 + 1
-            values = s0 + s1 + jgraph.node_properties[node]
-            result[num_results, :] = (float(id0), float(id1), d0 + d1,
-                                      float(kind), values / counts)
-            num_results += 1
+                if id0 == node:  # standalone cycle
+                    id1, d1, n1, s1, deg1 = node, 0, 0, 0., 2
+                    kind = 3
+                else:
+                    id1, d1, n1, s1, deg1 = _expand_path(jgraph, node, right,
+                                                         visited, degrees)
+                    kind = 2  # default: junction-to-junction
+                    if deg0 == 1 and deg1 == 1:  # tip-tip
+                        kind = 0
+                    elif deg0 == 1 or deg1 == 1:  # tip-junct, tip-path impossible
+                        kind = 1
+                counts = n0 + n1 + 1
+                values = s0 + s1 + jgraph.node_properties[node]
+                result[num_results, :] = (float(id0), float(id1), d0 + d1,
+                                          float(kind), values / counts)
+                num_results += 1
+            elif degrees[node] == 1:
+                visited[node] = True
+                neighbor = jgraph.neighbors(node)[0]
+                id0, d0, n0, s0, deg0 = _expand_path(jgraph, node, neighbor,
+                                                     visited, degrees)
+                kind = 1  # tip-junct
+                counts = n0 + 1
+                values = s0 + jgraph.node_properties[node]
+                result[num_results, :] = (float(node), float(id0), d0,
+                                          float(kind), values / counts)
     return num_results
 
 

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -379,11 +379,12 @@ def _branch_statistics_loop(jgraph, degrees, visited, result):
                 neighbor = jgraph.neighbors(node)[0]
                 id0, d0, n0, s0, deg0 = _expand_path(jgraph, node, neighbor,
                                                      visited, degrees)
-                kind = 1  # tip-junct
-                counts = n0 + 1
-                values = s0 + jgraph.node_properties[node]
+                kind = 1 if deg0 > 2 else 0  # tip-junct / tip-tip
+                counts = n0
+                values = s0
+                avg_value = np.nan if counts == 0 else values / counts
                 result[num_results, :] = (float(node), float(id0), d0,
-                                          float(kind), values / counts)
+                                          float(kind), avg_value)
                 num_results += 1
     return num_results
 

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -344,6 +344,7 @@ def _expand_path(graph, source, step, visited, degrees):
         visited[source] = True
         s += graph.node_properties[source]
         n += 1
+    visited[step] = True
     return step, d, n, s, degrees[step]
 
 

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -383,6 +383,7 @@ def _branch_statistics_loop(jgraph, degrees, visited, result):
                 values = s0 + jgraph.node_properties[node]
                 result[num_results, :] = (float(node), float(id0), d0,
                                           float(kind), values / counts)
+                num_results += 1
     return num_results
 
 

--- a/skan/test/test_csr.py
+++ b/skan/test/test_csr.py
@@ -7,7 +7,7 @@ rundir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(rundir)
 
 from skan._testdata import (tinycycle, tinyline, skeleton0, skeleton1,
-                            skeleton2, skeleton3d, topograph1d)
+                            skeleton2, skeleton3d, topograph1d, skeleton4)
 
 
 def test_tiny_cycle():
@@ -123,3 +123,8 @@ def test_pixel_values():
     expected = np.mean(image[1:-1])
     stats = csr.summarise(image)
     assert_almost_equal(stats.loc[0, 'mean pixel value'], expected)
+
+
+def test_tip_junction_edges():
+    stats1 = csr.summarise(skeleton4)
+    assert stats1.shape[0] == 3  # ensure all three branches are counted


### PR DESCRIPTION
Previously, skan needed a path to contain at least two edges (three nodes) to be counted. Therefore, direct tip-to-junction edges were ignored. This resulted in some discrepancies with Fiji's Analyze Skeletons, which this PR should rectify.

Fixes #45 