### PR TITLE
Fix Numba deprecation warning

### DIFF
--- a/skan/csr.py
+++ b/skan/csr.py
@@ -18,7 +18,7 @@ csr_spec = [
     ('node_properties', numba.float64[:])
 ]
 
-@numba.jitclass(csr_spec)
+@numba.experimental.jitclass(csr_spec)
 class NBGraph:
     def __init__(self, indptr, indices, data, shape, node_props):
         self.indptr = indptr


### PR DESCRIPTION
Change `@numba.jitclass(csr_spec)` to `@numba.experimental.jitclass(csr_spec)` to get rid of the Numba deprecation warning.