### PR TITLE
skan.csr: Clarify that a skeleton's distances list is initially empty

### DIFF
--- a/skan/csr.py
+++ b/skan/csr.py
@@ -306,7 +306,8 @@ class Skeleton:
         The number of paths, P. This is redundant information given `n_paths`,
         but it is used often enough that it is worth keeping around.
     distances : array of float, shape (P,)
-        The distance of each path.
+        The distance of each path. Note: not initialized until `path_lengths()`
+        is called on the skeleton; use path_lengths() instead
     skeleton_image : array or None
         The input skeleton image. Only present if `keep_images` is True. Set to
         False to preserve memory.


### PR DESCRIPTION
While working on a project using this library (which has been super helpful!), I noticed that the `distances` array for my skeleton seemed to contain very small values.  Looking at the code, it appears that `distances` is not initialized until the `path_lengths` method is called on a skeleton.  This is just a small change to indicate this fact in the docs to reduce confusion in the future.