### PR TITLE
Don't write into the location of the dummy pixel_indices coordinate

### DIFF
--- a/skan/csr.py
+++ b/skan/csr.py
@@ -316,7 +316,7 @@ class Skeleton:
         `keep_images` is True. This is useful for visualization.
     """
     def __init__(self, skeleton_image, *, spacing=1, source_image=None,
-                 _buffer_size_offset=None, keep_images=True, 
+                 _buffer_size_offset=None, keep_images=True,
                  unique_junctions=True):
         graph, coords, degrees = skeleton_to_csgraph(skeleton_image,
                                                      spacing=spacing,
@@ -608,8 +608,8 @@ def skeleton_to_csgraph(skel, *, spacing=1, value_is_height=False,
     pixel_indices = np.concatenate(([[0.] * ndim],
                                     np.transpose(np.nonzero(skel))), axis=0)
     skelint = np.zeros(skel.shape, dtype=int)
-    skelint[tuple(pixel_indices.T.astype(int))] = \
-                                            np.arange(pixel_indices.shape[0])
+    skelint[tuple(pixel_indices[1:].T.astype(int))] = \
+                                            np.arange(pixel_indices.shape[0])[1:]
 
     degree_kernel = np.ones((3,) * ndim)
     degree_kernel[(1,) * ndim] = 0  # remove centre pixel


### PR DESCRIPTION
@jni and I talked about how `pixel_indices` in `csr.py` always contains a dummy "coordinate" `[0, 0]`, regardless of whether that pixel coordinate is part of the skeleton or not. 

@jni says it's supposed to be there in `pixel_indices` for padding, so you can directly index into it using the pixell id number. This doesn't hold if you use the default `unique_junctions=True` kwarg, but will be the case if `unique_junctions=False`.

Anyway, we shouldn't be using this dummy coordinate to write into arrays. Currently skan is overwriting a zero value with another zero, which doesn't matter much. It is confusing when you start to poke around into how we could make this work in a distributed context.
