### PR TITLE
Add release-on-tag-push action

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,51 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build-and-publish:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: github.repository == 'jni/skan'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .  # need full install so we can build type stubs
+      - name: Build Distribution
+        run: python setup.py sdist bdist_wheel
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ env.tag }}
+          body_path: doc/release-notes/release-${{ env.tag }}.md
+          draft: false
+          prerelease: ${{ contains(github.ref, 'rc') }}
+      - name: Upload GitHub Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/skan-${{ env.tag }}.tar.gz
+          asset_name: dist-${{ env.tag }}.tar.gz
+          asset_content_type: application/gzip
+      - name: Publish PyPI Package
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This actually will (hopefully) allow us to publish skan releases by pushing a tag to GitHub.
