### PR TITLE
DOC Add versions to documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -46,7 +46,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           working-directory: doc
-          run: make html
+          run: sphinx-multiversion docs build/html
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,6 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install 'setuptools<50.0'
           python -m pip install .[all,testing,docs]
+          python -m pip install sphinx_multiversion
 
       - name: Get data
         working-directory: doc
@@ -46,7 +47,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           working-directory: doc
-          run: sphinx-multiversion docs build/html
+          run: @NAPARI_APPLICATION_IPY_INTERACTIVE=0 python sphinx-multiversion . _build
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/doc/_templates/versioning.html
+++ b/doc/_templates/versioning.html
@@ -1,0 +1,8 @@
+{% if versions %}
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+{% endif %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,7 @@ extensions = [
         'sphinx.ext.mathjax',
         'sphinx.ext.viewcode',
         'sphinx.ext.githubpages',
+        "sphinx_multiversion",
         'sphinx.ext.napoleon',
         'sphinxcontrib.bibtex',
         'sphinx_copybutton',
@@ -152,7 +153,10 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+    "**": [
+            "logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html",
+            "html"
+    ]
 }
 
 # -- Options for HTMLHelp output ------------------------------------------
@@ -207,3 +211,11 @@ texinfo_documents = [
                 'Skeleton analysis in Python.', 'Miscellaneous'
                 ),
         ]
+
+# sphinx-multiversion configuration
+smv_tag_whitelist = r'^v.*$'
+smv_branch_whitelist = None
+smv_remote_whitelist = None
+smv_released_pattern = r'^tags/.*$'
+# Use tag name for output directory
+smv_outputdir_format = '{ref.name}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,7 @@ html_static_path = ['_static']
 html_sidebars = {
     "**": [
             "logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html",
-            "html"
+            "versioning.html",
     ]
 }
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,6 +5,5 @@ tqdm>=4.11
 nb2plots>=0.5
 sphinxcontrib-bibtex
 sphinx<2
-sphinx_multiversion
 sphinx_rtd_theme
 seaborn>=0.9

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,5 +5,6 @@ tqdm>=4.11
 nb2plots>=0.5
 sphinxcontrib-bibtex
 sphinx<2
+sphinx_multiversion
 sphinx_rtd_theme
 seaborn>=0.9


### PR DESCRIPTION
Aims to build document for all tagged versions and add versions to sidebar of documentation.

Outlines steps required: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/configuring.html#add-a-dropdown-to-switch-between-docs-versions

First attempt tries using [sphinx-multiversion](https://holzhaus.github.io/sphinx-multiversion/master/quickstart.html) (as easier than writing all code our self). Note although this project has not seen much activity recently, see [this comment from the author](https://github.com/sphinx-contrib/sphinxcontrib-versioning/pull/78#issuecomment-599193860).
