### PR TITLE
DOC Prepend version with 'v' in switcher

### DIFF
--- a/doc/_static/version_switcher.json
+++ b/doc/_static/version_switcher.json
@@ -6,11 +6,11 @@
     },
     {
         "name": "0.10.x (stable)",
-        "version": "0.10.x",
+        "version": "v0.10.x",
         "url": "https://jni.github.io/skan/stable"
     },
     {
-        "version": "0.9.x",
-        "url": "https://jni.github.io/skan/0.9.x"
+        "version": "v0.9.x",
+        "url": "https://jni.github.io/skan/v0.9.x"
     }
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,7 +118,7 @@ version_match = pattern.search(version)
 if 'dev' in version:
     version_match = version
 elif version_match:
-    version_match = version_match.group() + ".x"
+    version_match = "v" + version_match.group() + ".x"
 
 # Material theme options (see theme.conf for more information)
 html_theme_options = {


### PR DESCRIPTION
Don't think this will fix the problem with the version switch drop down but standardises naming to add 'v' (which most other projects use)