### PR TITLE
Update dependencies' minimum version according to NEP-29

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,17 +47,17 @@ packages = find:
 python_requires = >=3.8
 include_package_data = True
 install_requires =
-    imageio>=2.0
-    matplotlib>=3.0
+    imageio>=2.10.1
+    matplotlib>=3.4
     networkx>=2.7
-    numba>=0.50
-    numpy>=1.16.5
-    pandas>=1.0
-    openpyxl>=2.4
-    scikit-image>=0.17
-    scipy>=1.2.0
+    numba>=0.53
+    numpy>=1.21
+    pandas>=1.3
+    openpyxl>=2.6
+    scikit-image>=0.17.1
+    scipy>=1.7
     toolz>=0.10.0
-    tqdm>=4.56.0
+    tqdm>=4.57.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Follows [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) recommendations for minimum version requirements.
