### PR TITLE
🐞 Bug Fix: Include `napari.yaml` in build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
 where = src
 
 [options.package_data]
-* = *.tif, *.zarr, *.zip
+* = *.tif, *.zarr, *.zip, *napari.yaml
 
 [options.extras_require]
 all =


### PR DESCRIPTION
Noticed that the napari plugin wasn't discovered when installing from `pypi`.
This was due to defining strict package data. I added `napari.yaml` to that list.
To check it worked, I built a wheel and installed from it locally.
This means we will need to release again, sorry @jni 