### PR TITLE
Improved error reporting and tests for prune_paths() methods

### DIFF
--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -6,7 +6,7 @@ from scipy.spatial import distance_matrix
 from skimage import morphology
 from skimage.graph import central_pixel
 from skimage.util._map_array import map_array, ArrayMap
-from typing import List
+import numpy.typing as npt
 import numba
 import warnings
 
@@ -656,7 +656,7 @@ class Skeleton:
         means = self.path_means()
         return np.sqrt(np.clip(sumsq/lengths - means*means, 0, None))
 
-    def prune_paths(self, indices: List[int]) -> 'Skeleton':
+    def prune_paths(self, indices: npt.ArrayLike) -> 'Skeleton':
         """Prune nodes from the skeleton.
 
         Parameters

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -671,10 +671,12 @@ class Skeleton:
         """
         # warning: slow
         image_cp = np.copy(self.skeleton_image)
-        if np.any(np.array(indices) > self.paths.shape[1]):
+        if not np.all(np.array(indices) < self.n_paths):
             raise ValueError(
-                    f'The path index {i} does not exist in the '
-                    'summary dataframe. Resummarise the skeleton.'
+                    f'The path index {np.max(indices)} does not exist in this '
+                    f'skeleton. (The highest path index is {self.n_paths}.)\n'
+                    'If you obtained the index from a summary table, you '
+                    'probably need to resummarize the skeleton.'
                     )
         for i in indices:
             pixel_ids_to_wipe = self.path(i)

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -14,7 +14,9 @@ from .nputil import _raveled_offsets_and_distances
 from .summary_utils import find_main_branches
 
 
-def _weighted_abs_diff(values0: np.ndarray, values1: np.ndarray, distances: np.ndarray) -> np.ndarray:
+def _weighted_abs_diff(
+        values0: np.ndarray, values1: np.ndarray, distances: np.ndarray
+        ) -> np.ndarray:
     """A default edge function for complete image graphs.
 
     A pixel graph on an image with no edge values and no mask is a very
@@ -671,9 +673,9 @@ class Skeleton:
         image_cp = np.copy(self.skeleton_image)
         if np.any(np.array(indices) > self.paths.shape[1]):
             raise ValueError(
-                        f'The path index {i} does not exist in the '
-                        'summary dataframe. Resummarise the skeleton.'
-                        )
+                    f'The path index {i} does not exist in the '
+                    'summary dataframe. Resummarise the skeleton.'
+                    )
         for i in indices:
             pixel_ids_to_wipe = self.path(i)
             junctions = self.degrees[pixel_ids_to_wipe] > 2
@@ -696,7 +698,10 @@ class Skeleton:
 
 
 def summarize(
-        skel: Skeleton, *, value_is_height: bool=False, find_main_branch: bool=False
+        skel: Skeleton,
+        *,
+        value_is_height: bool = False,
+        find_main_branch: bool = False
         ) -> pd.DataFrame:
     """Compute statistics for every skeleton and branch in ``skel``.
 


### PR DESCRIPTION
Closes #206

The error arises during usage of `csr.Skeleton.prune_paths()` which takes a list of indices, typical from `csr.summarize()`, which are to be pruned. If the index is outside of the range of rows in the data frame a `ValueError` is thrown.

It was first highlighted during early development of pruning iteratively but can arise any time in inappropriate value that is greater than the number of paths in a skeleton is passed to `prune_path()` method.

A `try: ... except: ...` is introduced to capture this and report, hopefully informatively, what the problem is and how to correct it. Tests are introduced for this method, parametrized to test removing different types of paths along with tests of two exceptions that can arise.