### PR TITLE
Fix documentation builds

### DIFF
--- a/doc/examples/complete_analysis.md
+++ b/doc/examples/complete_analysis.md
@@ -196,7 +196,7 @@ ax[2].set_ylabel('density')
 # Finally, a panel grouping the data by cell, showing the difference
 # between infected and uninfected cells
 cellmeans = (datar.groupby(['infection', 'cell number'])
-                  .mean().reset_index())
+                  .mean(numeric_only=True).reset_index())
 sns.stripplot(x='infection', y='branch distance (nm)', data=cellmeans,
               jitter=True, order=('normal', 'infected'), ax=ax[3])
               

--- a/doc/examples/visualizing_3d_skeletons.md
+++ b/doc/examples/visualizing_3d_skeletons.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.10.3
+    jupytext_version: 1.14.6
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -107,35 +107,8 @@ skeleton_layer.face_colormap = 'viridis'
 ```
 
 ```{code-cell} ipython3
-:tags: ["remove-input"]
+:tags: [remove-input]
+
 viewer.camera.angles = (-30, 30, -135)
 napari.utils.nbscreenshot(viewer)
-```
-
-## Using the Labels layer
-
-We can also visualize the pixels of the skeleton as a Labels layer, with each path ID appearing as a different label. The downside with this approach is that junction pixels are arbitrarily assigned to one of the branches incident on that junction. Therefore, removing that branch would cause the junction pixel to be removed, which could incorrectly disconnect the skeleton at that point.
-
-However, the rich 3D interactivity of the labels layer does allow prunning of branches in 3D, which could be extremely useful for manual curation of the skeleton, as long as propert care is taken in downstream processing of the edits.
-
-```{code-cell} ipython3
-labels = np.asarray(skeleton)
-
-viewer2 = napari.view_labels(
-        labels,
-        properties=paths_table,
-        opacity=1,
-        ndisplay=3,
-        )
-```
-
-```{code-cell} ipython3
-:tags: ["remove-input"]
-viewer2.camera.angles = (-30, 30, -135)
-viewer2.camera.zoom = 6.5
-napari.utils.nbscreenshot(viewer2)
-```
-
-```{code-cell} ipython3
-
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     'sphinxcontrib-bibtex',
     'myst-nb',
     'zarr',
-    'pydata-sphinx-theme==0.8.1'
+    'pydata-sphinx-theme<1.0'
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
     'sphinx',
     'jupyter',
     'notebook',
-    'seaborn<1.0',
+    'seaborn>=0.13,<1.0',
     'sphinx-toggleprompt',
     'sphinx-copybutton',
     'sphinxcontrib-bibtex',

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -506,12 +506,10 @@ class Skeleton:
                 spacing=spacing,
                 value_is_height=value_is_height,
                 )
-        if np.issubdtype(skeleton_image.dtype, np.float_):
+        if np.issubdtype(skeleton_image.dtype, np.floating):
             self.pixel_values = skeleton_image[coords]
-        elif np.issubdtype(skeleton_image.dtype, np.int_):
+        elif np.issubdtype(skeleton_image.dtype, np.integer):
             self.pixel_values = skeleton_image.astype(float)[coords]
-        elif np.issubdtype(skeleton_image.dtype, np.bool_):
-            self.pixel_values = None
         else:
             self.pixel_values = None
         self.graph = graph

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -512,6 +512,8 @@ class Skeleton:
             self.pixel_values = skeleton_image.astype(float)[coords]
         elif np.issubdtype(skeleton_image.dtype, np.bool_):
             self.pixel_values = None
+        else:
+            self.pixel_values = None
         self.graph = graph
         self.nbgraph = csr_to_nbgraph(graph, self.pixel_values)
         self.coordinates = np.transpose(coords)

--- a/src/skan/test/test_csr.py
+++ b/src/skan/test/test_csr.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from itertools import product
 
 import pytest
 import numpy as np
@@ -316,8 +317,16 @@ def test_skeleton_path_image_no_keep_image():
     assert np.max(pli) == s.n_paths
 
 
-def test_skeletonlabel():
-    stats = csr.summarize(csr.Skeleton(skeletonlabel), separator='_')
+@pytest.mark.parametrize(
+        'dtype', [
+                ''.join([pre, 'int', suf])
+                for pre, suf in product(['u', ''], ['8', '16', '32', '64'])
+                ]
+        )
+def test_skeleton_integer_dtype(dtype):
+    stats = csr.summarize(
+            csr.Skeleton(skeletonlabel.astype(dtype)), separator='_'
+            )
     assert stats['mean_pixel_value'].max() == skeletonlabel.max()
     assert stats['mean_pixel_value'].max() > 1
 


### PR DESCRIPTION
Some pages aren't building correctly because of changes in our dependencies or
small internal bugs. This PR aims to get every page to build correctly again
without warnings.

- Update pandas groupby.mean for pandas >2
- Ensure newer seaborn is used for docs
- Fix calls to np.issubdtype — np.int_ isn't a base dtype, it's np.integer
- improve test for int dtype skeletons
