### PR TITLE
fix(csr): Set type of node_props to float64

### DIFF
--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -207,7 +207,7 @@ def csr_to_nbgraph(csr, node_props=None):
             csr.indices,
             csr.data,
             np.array(csr.shape, dtype=np.int32),
-            node_props,
+            node_props.astype(np.float64),
             )
 
 


### PR DESCRIPTION
`dtype` of `node_props` passed from `csr_to_nbgraph()` to `NBGraph` was `float32`. This sets the type to explicitly be `np.float64` which matches the expectation of `csr_spec_float` passed to `numba.experimental.jitclass()`.

The tests that were previously failing in [TopoStats](https://github.com/AFM-SPM/TopoStats/) (see #234 for details) now pass locally. :slightly_smiling_face: 