### PR TITLE
'skeleton_id' to 'skeleton-id'

### DIFF
--- a/doc/examples/visualizing_3d_skeletons.md
+++ b/doc/examples/visualizing_3d_skeletons.md
@@ -99,10 +99,10 @@ napari.utils.nbscreenshot(viewer)
 Finally, we can color the paths by a numerical property, such as their length.
 
 ```{code-cell} ipython3
-skeleton_layer.edge_color = 'branch_distance'
+skeleton_layer.edge_color = 'branch-distance'
 skeleton_layer.edge_colormap = 'viridis'
 # for now, we need to set the face color as well
-skeleton_layer.face_color = 'branch_distance'
+skeleton_layer.face_color = 'branch-distance'
 skeleton_layer.face_colormap = 'viridis'
 ```
 

--- a/doc/examples/visualizing_3d_skeletons.md
+++ b/doc/examples/visualizing_3d_skeletons.md
@@ -85,9 +85,9 @@ napari.utils.nbscreenshot(viewer)
 We can also demonstrate that most of these branches are in one skeleton, with a few stragglers around the edges, by coloring by skeleton ID:
 
 ```{code-cell} ipython3
-skeleton_layer.edge_color = 'skeleton_id'
+skeleton_layer.edge_color = 'skeleton-id'
 # for now, we need to set the face color as well
-skeleton_layer.face_color = 'skeleton_id'
+skeleton_layer.face_color = 'skeleton-id'
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Otherwise, I was not able to get https://skeleton-analysis.org/stable/examples/visualizing_3d_skeletons.html to work...

I found the correct value with
```python
for i in paths_table:
    print(i)
```
which gave me 
```
skeleton-id
node-id-src
node-id-dst
branch-distance
branch-type
mean-pixel-value
stdev-pixel-value
image-coord-src-0
image-coord-src-1
image-coord-src-2
image-coord-dst-0
image-coord-dst-1
image-coord-dst-2
coord-src-0
coord-src-1
coord-src-2
coord-dst-0
coord-dst-1
coord-dst-2
euclidean-distance
path_id
random_path_id
```
