### PR TITLE
Add write permissions to deploy docs action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
 
   build-and-deploy:


### PR DESCRIPTION
This is needed by more recent versions of the pages-deploy action.
