### PR TITLE
Don't use full version info for deploy action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,7 +60,7 @@ jobs:
           run: make -C doc html
 
       - name: Deploy dev docs 🚀
-        uses: JamesIves/github-pages-deploy-action@4.7.3
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages
           folder: doc/_build/html
@@ -68,7 +68,7 @@ jobs:
           clean: true
 
       - name: Deploy stable docs 🚀
-        uses: JamesIves/github-pages-deploy-action@4.7.3
+        uses: JamesIves/github-pages-deploy-action@4
         if: startsWith(env.TAG, 'v')
         with:
           branch: gh-pages


### PR DESCRIPTION
Another attempt to fix deployment with
JamesIves/github-pages-deploy-action.

But to be honest I am just fumbling around in the dark here. The only
information I can find about "Missing download info" in GHA is this
discussion:

https://github.com/orgs/community/discussions/152695

which relates to a version of actions/upload-artifact that was no
longer available. That doesn't seem to be the case for
JamesIves/github-pages-deploy-action, which currently shows the 4.7.3
tag on the repo.
