### PR TITLE
New API: PathGraph dataclass

### DIFF
--- a/doc/misc/release-notes/release-v0.13.md
+++ b/doc/misc/release-notes/release-v0.13.md
@@ -1,0 +1,29 @@
+# skan v0.13.0
+
+This is a minor step forward from v0.12.x which adds a new API:
+`skan.csr.PathGraph` is a more abstract version of a Skeleton, which only
+needs a pixel adjacency matrix to work, rather than a full skeleton image.
+The motivations for PathGraph are numerous:
+
+- a simpler dataclass object that doesn't require complex instantiation
+  logic. See e.g. Glyph's [Stop Writing `__init__`
+  Methods](https://blog.glyph.im/2025/04/stop-writing-init-methods.html)
+- making it easier to compute the pixel adjacency matrix separately, for
+  example [using dask when the images don't fit in
+  memory](https://blog.dask.org/2021/05/07/skeleton-analysis), and having
+  an API for which you can provide this matrix (rather than having to
+  modify a Skeleton instance in-place).
+- allowing more flexible use cases, for example to use skan to measure
+  tracks, as in
+  [live-image-tracking-tools/traccuracy#251](https://github.com/live-image-tracking-tools/traccuracy/pull/251).
+
+Due to some urgent need to use this code in the wild, this release doesn't
+provide any documentation examples. Indeed, the new class may see some changes
+in upcoming releases based on user feedback. See the discussion in
+[jni/skan#246](https://github.com/jni/skan/pull/246) for details. Look for
+further refinement of this idea in the 0.13.x releases!
+
+## New features
+
+- [#246](https://github.com/jni/skan/pull/246): New API: PathGraph dataclass
+

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -207,8 +207,8 @@ def csr_to_nbgraph(csr, node_props=None):
         node_props = np.broadcast_to(1., csr.shape[0])
         node_props.flags.writeable = True
     return NBGraph(
-            csr.indptr,
-            csr.indices,
+            csr.indptr.astype(np.int32, copy='False'),
+            csr.indices.astype(np.int32, copy='False'),
             csr.data,
             np.array(csr.shape, dtype=np.int32),
             node_props.astype(np.float64),

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -475,12 +475,34 @@ class PathGraph:
 
     @classmethod
     def from_graph(cls, *, adj, node_coordinates, node_values=None, spacing=1):
+        """Build a PathGraph from an adjacency matrix and node coordinates.
+
+        Parameters
+        ----------
+        adj : scipy.sparse.csr_array
+            An adjacency matrix where adj[i, j] is nonzero iff there is an
+            edge between node i and node j.
+        node_coordinates : np.ndarray, shape (N, ndim)
+            The coordinates of the nodes. node_coordinates[i] is the
+            coordinate of node i. The indices of these coordinates must match
+            the indices of adj.
+        node_values : np.ndarray, shape (N,)
+            Values of the nodes. Could be image intensity, height, or some
+            other quantity of which you want to compute statistics along the
+            path.
+        spacing : float or tuple of float, shape (ndim,)
+            The pixel/voxel spacing along each axis coordinate.
+        """
         nbgraph = csr_to_nbgraph(adj, node_values)
         paths = _build_skeleton_path_graph(nbgraph)
         return cls(adj, node_coordinates, node_values, paths, spacing)
 
     @classmethod
     def from_image(cls, skeleton_image, *, spacing=1, value_is_height=False):
+        """Build a PathGraph from a skeleton image.
+
+        This is just a convenience meant to mirror Skeleton.__init__.
+        """
         graph, coords = skeleton_to_csgraph(
                 skeleton_image,
                 spacing=spacing,
@@ -500,6 +522,13 @@ class PathGraph:
 
     @cached_property
     def distances(self):
+        """The path distances.
+
+        Returns
+        -------
+        distances : np.ndarray of float, shape (P,)
+            distances[i] contains the distance of path i.
+        """
         distances = np.empty(self.n_paths, dtype=float)
         _compute_distances(
                 self.nbgraph, self.paths.indptr, self.paths.indices, distances
@@ -512,6 +541,12 @@ class PathGraph:
 
     @cached_property
     def degrees(self):
+        """The degree (number of neighbors) of each node/pixel.
+
+        Returns
+        -------
+        degrees : np.ndarray of int, shape (N,)
+        """
         return np.diff(self.adj.indptr)
 
 

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -207,8 +207,8 @@ def csr_to_nbgraph(csr, node_props=None):
         node_props = np.broadcast_to(1., csr.shape[0])
         node_props.flags.writeable = True
     return NBGraph(
-            csr.indptr.astype(np.int32, copy='False'),
-            csr.indices.astype(np.int32, copy='False'),
+            csr.indptr.astype(np.int32, copy=False),
+            csr.indices.astype(np.int32, copy=False),
             csr.data,
             np.array(csr.shape, dtype=np.int32),
             node_props.astype(np.float64),
@@ -414,8 +414,9 @@ def _build_skeleton_path_graph(graph):
     degrees = np.diff(graph.indptr)
     visited_data = np.zeros(graph.data.shape, dtype=bool)
     visited = NBGraphBool(
-            graph.indptr, graph.indices, visited_data, graph.shape,
-            np.broadcast_to(1.0, graph.shape[0])
+            graph.indptr.astype(np.int32, copy=False),
+            graph.indices.astype(np.int32, copy=False), visited_data,
+            graph.shape, np.broadcast_to(1.0, graph.shape[0])
             )
     endpoints = (degrees != 2)
     endpoint_degrees = degrees[endpoints]

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -823,7 +823,7 @@ class Skeleton:
 
 
 def summarize(
-        skel: Skeleton,
+        skel: Skeleton | PathGraph,
         *,
         value_is_height: bool = False,
         find_main_branch: bool = False,
@@ -856,6 +856,8 @@ def summarize(
         A summary of the branches including branch length, mean branch value,
         branch euclidean distance, etc.
     """
+    if isinstance(skel, PathGraph):
+        skel = Skeleton.from_path_graph(skel)
     if separator is None:
         warnings.warn(
                 "separator in column name will change to _ in version 0.13; "

--- a/src/skan/csr.py
+++ b/src/skan/csr.py
@@ -517,7 +517,7 @@ class PathGraph:
 
 
 def _extract_values(image, coords):
-    if image.dtype == np.bool:
+    if image.dtype == np.bool_:
         return None
     values = image[coords]
     output_dtype = (


### PR DESCRIPTION
The Skeleton class is a bit of a hodgepodge of data, generated data,
things that should be properties, manually cached properties, and
functions that should not be part of the class at all. Thanks to the
helpful prodding of @kevinyamauchi, this PR attempts to simplify the
concepts and data structures in skan into a simple class that can be
created without an image — since the path graph, not the image, is the
core of the computational abilities of skan.

This is still a work in progress but should already be useful: if you
have a graph as a `scipy.sparse.csr_array` (note: `csr_array`, not the
deprecated `csr_matrix` used by skan so far) generated through your own
means, you can make a "Skeleton" as follows:

```python
from skan.csr import PathGraph, Skeleton, summarize

g = PathGraph.from_graph(
        node_coordinates=coordinates,  # (n, ndim) NumPy array
        graph=graph,  # scipy.sparse.csr_array
        )

s = Skeleton.from_path_graph(g)
summary = summarize(s, separator='_')
```

Still to do in this PR:

- allow making PathGraphs from Skeletons
- allow `summarize` to take in PathGraphs directly

In the future, we might want to deprecate Skeleton altogether, but I'm
happy to do this over a long time.

@kevinyamauchi, I'm curious what you think about `paths` being a data
attribute, even though it is generated. I think it's expensive enough to
compute that we want it to be data and serializable. But it kinda breaks
the dataclass paradigm a little bit.

@DragaDoncila, you should be able to pull down this branch and use it on
your networkx tracking graphs after exporting them to csr arrays (I'm
pretty sure that's built-in to nx).

